### PR TITLE
Update protocol for URL of root-config.js

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -11,7 +11,7 @@
   <script type="systemjs-importmap">
     {
       "imports": {
-        "@vue-mf/root-config": "https://localhost:9000/vue-mf-root-config.js"
+        "@vue-mf/root-config": "//localhost:9000/vue-mf-root-config.js"
       }
     }
   </script>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -11,7 +11,7 @@
   <script type="systemjs-importmap">
     {
       "imports": {
-        "@vue-mf/root-config": "http://localhost:9000/vue-mf-root-config.js"
+        "@vue-mf/root-config": "https://localhost:9000/vue-mf-root-config.js"
       }
     }
   </script>


### PR DESCRIPTION
When running the app with `yarn start --https`, it fails to load `vue-mf-root-config.js` as URL for it contains `http` protocol. So it can't find this file with http protocol, as it's served with https protocol.  

Update URL for `@vue-mf/root-config"` in `index.ejs` to use URL with https.